### PR TITLE
Adding coverage + makefile entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ twitchvod.egg-info/
 dist/
 build/
 .pytest_cache
+.coverage

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ lint:
 
 test:
 	pytest
+
+coverage:
+	pytest --cov-report term-missing --cov=twitchvod/ tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.21.0
 pytest==4.1.1
+coverage==4.5.2
+pytest-cov==2.6.1


### PR DESCRIPTION
Adding coverage with makefile command.

`make coverage`

![image](https://user-images.githubusercontent.com/3413677/52105382-2238ce80-25b4-11e9-9c7e-f70d79d01238.png)
